### PR TITLE
Use ADC-scan

### DIFF
--- a/mcu/application/adc.c
+++ b/mcu/application/adc.c
@@ -3,16 +3,20 @@
 #include "em_chip.h"
 #include "em_cmu.h"
 #include "em_gpio.h"
-extern ADC_InitSingle_TypeDef initSingle;
 
-void initADC_single(int ref) {
+extern ADC_InitScan_TypeDef initScan;
+
+void initADC_scan(int ref) {
   CMU_ClockEnable(cmuClock_ADC0, true);
   ADC_Init_TypeDef init = ADC_INIT_DEFAULT;
+  init.prescale = 255;
   ADC_Init(ADC0, &init);
-  initSingle.reference = ref;
-  ADC_InitSingle(ADC0, &initSingle);
+  initScan.reference = ref;
+  initScan.input = ADC_SCANCTRL_INPUTMASK_CH4;
+  ADC_InitScan(ADC0, &initScan);
 
   // Enable interrupts
-  ADC_IntEnable(ADC0, ADC_IEN_SINGLE);
+  ADC_IntEnable(ADC0, ADC_IEN_SCAN);
+  ADC_IntEnable(ADC0, ADC_IEN_SCANOF);
   NVIC_EnableIRQ(ADC0_IRQn);
 }

--- a/mcu/application/adc.h
+++ b/mcu/application/adc.h
@@ -1,5 +1,5 @@
 // Initialize the ADC for single input samples using VDD for reference
-void initADC_single(int ref);
+void initADC_scan(int ref);
 
 // Handler for reading the value from the ADC
 void ADC0_IRQHandler(void);

--- a/mcu/application/main.c
+++ b/mcu/application/main.c
@@ -11,8 +11,8 @@
 #include "spidrv.h"
 #include "timer.h"
 
-#include <math.h>
 #include "linalg.h"
+#include <math.h>
 
 #define SPI_BITRATE 1000000
 
@@ -40,81 +40,80 @@
 uint32_t ch1_sample;
 uint32_t ch2_sample;
 uint32_t adcChannel = 0;
-ADC_InitSingle_TypeDef initSingle = ADC_INITSINGLE_DEFAULT;
 SPIDRV_HandleData_t handleData;
 SPIDRV_Handle_t handle = &handleData;
+ADC_InitScan_TypeDef initScan = ADC_INITSCAN_DEFAULT;
 
 vec3_t square[4];
 
-void calc_points(uint32_t ch1_sample, uint32_t ch2_sample, int16_t *coordinates) {
-    // This starts with our model square [-1, 1] x [-1, 1], and
-    // applies a scale-, a rotation-, and a translation-transform
-    // defined by potentiometer positions so that changing one
-    // will move the square vertically, and changing the other
-    // will rotate the square.
-    //
-    // In total, we end up doing 2 matrix multiplications and
-    // 4 matrix-vector multiplications, which is around 60
-    // floating point operations per interrupt. At 60 FPS, this
-    // means the processor needs to do ~4000 FLOPS.
+void calc_points(uint32_t ch1_sample, uint32_t ch2_sample,
+                 int16_t *coordinates) {
+  // This starts with our model square [-1, 1] x [-1, 1], and
+  // applies a scale-, a rotation-, and a translation-transform
+  // defined by potentiometer positions so that changing one
+  // will move the square vertically, and changing the other
+  // will rotate the square.
+  //
+  // In total, we end up doing 2 matrix multiplications and
+  // 4 matrix-vector multiplications, which is around 60
+  // floating point operations per interrupt. At 60 FPS, this
+  // means the processor needs to do ~4000 FLOPS.
 
-    double scale; // normalized potentiometer position [0, 1]
+  double scale; // normalized potentiometer position [0, 1]
 
-    // Channel 1 determines vertical offset y.
-    scale = (double)ch1_sample / MAX_SAMPLE;
-    float y = (2 * scale - 1.0) * MAX_DY; // [-MAX_DY, MAX_DY]
+  // Channel 1 determines vertical offset y.
+  scale = (double)ch1_sample / MAX_SAMPLE;
+  float y = (2 * scale - 1.0) * MAX_DY; // [-MAX_DY, MAX_DY]
 
-    // Channel 2 determines rotation theta.
-    scale = (double)ch2_sample / MAX_SAMPLE;
-    float th = (2 * scale - 1.0) * M_PI;
+  // Channel 2 determines rotation theta.
+  scale = (double)ch2_sample / MAX_SAMPLE;
+  float th = (2 * scale - 1.0) * M_PI;
 
-    float zoom = 30.0;
-    mat3_t S, R, T; // scaling, rotation and translation matrices.
+  float zoom = 30.0;
+  mat3_t S, R, T; // scaling, rotation and translation matrices.
 
-    // Scale x,y coordinates by zoom level.
-    mat3(&S, zoom,  0.0, 0.0,
-              0.0, zoom, 0.0,
-              0.0,  0.0, 1.0);
+  // Scale x,y coordinates by zoom level.
+  mat3(&S, zoom, 0.0, 0.0, 0.0, zoom, 0.0, 0.0, 0.0, 1.0);
 
-    // Rotate by theta radians.
-    rot3(&R, th);
+  // Rotate by theta radians.
+  rot3(&R, th);
 
-    // Translate to center of the screen +/- y-offset.
-    translation3(&T, DISPLAY_WIDTH / 2, (DISPLAY_HEIGHT / 2) + y);
+  // Translate to center of the screen +/- y-offset.
+  translation3(&T, DISPLAY_WIDTH / 2, (DISPLAY_HEIGHT / 2) + y);
 
-    // Create the "final" transformation matrix.
-    mat3_t SR, TSR;
-    mmul3(&SR, &S, &R);
-    mmul3(&TSR, &T, &SR);
+  // Create the "final" transformation matrix.
+  mat3_t SR, TSR;
+  mmul3(&SR, &S, &R);
+  mmul3(&TSR, &T, &SR);
 
-    // Iterate over the vertices.
-    for (int i = 0; i < 8; i = i + 2) {
-        // Calculate transformed vertex q = (TSR)v for all v in the square.
-        vec3_t q;
-        transform3(&q, &TSR, &square[i/2]);
+  // Iterate over the vertices.
+  for (int i = 0; i < 8; i = i + 2) {
+    // Calculate transformed vertex q = (TSR)v for all v in the square.
+    vec3_t q;
+    transform3(&q, &TSR, &square[i / 2]);
 
-        // Put the transformed coordinates in the coordinate buffer.
-        // These are already floats in pixel-coordinates, so we only
-        // need to cast them to int16, and then they are ready.
-        coordinates[i]     = (int16_t) q.x;
-        coordinates[i + 1] = (int16_t) q.y;
-    }
+    // Put the transformed coordinates in the coordinate buffer.
+    // These are already floats in pixel-coordinates, so we only
+    // need to cast them to int16, and then they are ready.
+    coordinates[i] = (int16_t)q.x;
+    coordinates[i + 1] = (int16_t)q.y;
+  }
 }
 
 void transmit_square(int16_t *coordinates) {
-    // Transmit the coordinates of a square as 4 pairs of
-    // 16-bit integers. This handles changing the byte-
-    // order.
+  // Transmit the coordinates of a square as 4 pairs of
+  // 16-bit integers. This handles changing the byte-
+  // order.
 
-    for (int i = 0; i < 8; i++) {
-        // Flip the order of the bytes.
-        uint8_t bitstream[2];
-        bitstream[0] = (coordinates[i] >> 8) & 0xFF;
-        bitstream[1] =  coordinates[i]       & 0xFF;
+  for (int i = 0; i < 8; i++) {
+    // Flip the order of the bytes.
+    uint8_t bitstream[2];
+    bitstream[0] = (coordinates[i] >> 8) & 0xFF;
+    bitstream[1] = coordinates[i] & 0xFF;
 
-        // Invoke the SPI driver to transfer the bitstream.
-        SPIDRV_MTransmitB(handle, bitstream, sizeof(bitstream));
-    }
+    // Invoke the SPI driver to transfer the bitstream.
+    SPIDRV_MTransmitB(handle, bitstream, sizeof(bitstream));
+  }
 }
 
 void GPIO_EVEN_IRQHandler(void) {
@@ -123,44 +122,53 @@ void GPIO_EVEN_IRQHandler(void) {
 }
 
 void TIMER1_IRQHandler(void) {
-    // The square has 8 coordinates.
-    int16_t coordinates[8] = {0};
+  // The square has 8 coordinates.
+  int16_t coordinates[8] = {0};
 
-    TIMER_IntClear(TIMER1, 1);
-    if (adcChannel)
-        initSingle.input = adcSingleInputCh4;
-    else
-        initSingle.input = adcSingleInputCh5;
-    ADC_InitSingle(ADC0, &initSingle);
-    ADC_Start(ADC0, adcStartSingle);
-    adcChannel = !adcChannel;
+  TIMER_IntClear(TIMER1, 1);
+  ADC_Start(ADC0, adcStartScan);
 
-    calc_points(ch1_sample, ch2_sample, coordinates);
-    transmit_square(coordinates);
+  calc_points(ch1_sample, ch2_sample, coordinates);
+  transmit_square(coordinates);
+  if (ch1_sample > 2048)
+    GPIO_PinOutSet(BSP_GPIO_LED0_PORT, BSP_GPIO_LED0_PIN);
+  else
+    GPIO_PinOutClear(BSP_GPIO_LED0_PORT, BSP_GPIO_LED0_PIN);
+  if (ch2_sample > 2048)
+    GPIO_PinOutSet(BSP_GPIO_LED1_PORT, BSP_GPIO_LED1_PIN);
+  else
+    GPIO_PinOutClear(BSP_GPIO_LED1_PORT, BSP_GPIO_LED1_PIN);
 }
 
 void ADC0_IRQHandler(void) {
-  ADC_IntClear(ADC0, ADC_IFC_SINGLE);
-  uint32_t sample = ADC_DataSingleGet(ADC0);
-  if (adcChannel)
+  ADC_IntClear(ADC0, ADC_IFC_SCAN);
+  ADC_IntClear(ADC0, ADC_IFC_SCANOF);
+  uint32_t sample = ADC_DataScanGet(ADC0);
+  if ((ADC0->STATUS & 0x0F000000) == 0x04000000)
     ch1_sample = sample;
-  else
+  if ((ADC0->STATUS & 0x0F000000) == 0x05000000)
     ch2_sample = sample;
+  if (adcChannel)
+    initScan.input = ADC_SCANCTRL_INPUTMASK_CH4;
+  else
+    initScan.input = ADC_SCANCTRL_INPUTMASK_CH5;
+  ADC_InitScan(ADC0, &initScan);
+  adcChannel = !adcChannel;
 }
 
 int main(void) {
   // Create the model (the square with w=1).
-  vec3(&square[0], -1.0,  1.0, 1.0);
+  vec3(&square[0], -1.0, 1.0, 1.0);
   vec3(&square[1], -1.0, -1.0, 1.0);
-  vec3(&square[2],  1.0, -1.0, 1.0);
-  vec3(&square[3],  1.0,  1.0, 1.0);
+  vec3(&square[2], 1.0, -1.0, 1.0);
+  vec3(&square[3], 1.0, 1.0, 1.0);
 
   uint32_t bitrate = 0;
   // Initializations
   CMU_ClockSelectSet(cmuClock_HF, cmuSelect_HFXO);
   initGPIO();
   initTimer(30);
-  initADC_single(adcRefVDD);
+  initADC_scan(adcRefVDD);
   TIMER_Enable(TIMER1, true);
 
   SPIDRV_Init_t initData = SPIDRV_MASTER_USART1;


### PR DESCRIPTION
Use ADC-scan instead for single polling to read the values from the joystick/potentiometers. This fixes the bugs where the value of one pin affects the value of the other