### PR TITLE
3D rendering wireframe cube with normalization

### DIFF
--- a/fpga/src/main/scala/matrix/Matrix.scala
+++ b/fpga/src/main/scala/matrix/Matrix.scala
@@ -4,7 +4,7 @@ import chisel3._
 import chisel3.experimental._
 import tools._
 
-class MVP(dim: Int = STD.pointNum) extends Module {
+class MVP(dim: Int = STD.pointDimension) extends Module {
   val io = IO(new Bundle {
     val vec4 = Input(Vec(dim, STD.FP))
     val mat4 = Input(Vec(dim, Vec(dim, STD.FP)))

--- a/fpga/src/main/scala/tools/Float.scala
+++ b/fpga/src/main/scala/tools/Float.scala
@@ -1,0 +1,75 @@
+package tools
+
+import chisel3._
+import chisel3.util._
+
+class fix_to_float extends BlackBox {
+  val io = IO(new Bundle {
+    val aclk = Input(Clock())
+    val s_axis_a_tvalid = Input(Bool())
+    val s_axis_a_tdata = Input(STD.FP)
+    val m_axis_result_tvalid = Output(Bool())
+    val m_axis_result_tdata = Output(Bits(32.W))
+  })
+}
+
+class float_to_fix extends BlackBox {
+  val io = IO(new Bundle {
+    val aclk = Input(Clock())
+    val s_axis_a_tvalid = Input(Bool())
+    val s_axis_a_tdata = Input(Bits(32.W))
+    val m_axis_result_tvalid = Output(Bool())
+    val m_axis_result_tdata = Output(STD.FP)
+  })
+}
+
+class float_div extends BlackBox {
+  val io = IO(new Bundle {
+    val aclk = Input(Clock())
+    val s_axis_a_tvalid = Input(Bool())
+    val s_axis_a_tdata = Input(Bits(32.W))
+    val s_axis_b_tvalid = Input(Bool())
+    val s_axis_b_tdata = Input(Bits(32.W))
+    val m_axis_result_tvalid = Output(Bool())
+    val m_axis_result_tdata = Output(Bits(32.W))
+  })
+}
+
+class FixPointDivision extends Module {
+  val io = IO(new Bundle {
+    val divisor = Input(STD.FP)
+    val divident = Input(STD.FP)
+    val inputReady = Input(Bool())
+
+    val result = Output(STD.FP)
+    val resultReady = Output(Bool())
+  })
+
+  val fix_to_float_a = Module(new fix_to_float)
+  val fix_to_float_b = Module(new fix_to_float)
+  val float_to_fix = Module(new float_to_fix)
+  val float_div = Module(new float_div)
+
+  fix_to_float_a.io.aclk := clock
+  fix_to_float_b.io.aclk := clock
+  float_to_fix.io.aclk := clock
+  float_div.io.aclk := clock
+
+  fix_to_float_a.io.s_axis_a_tvalid := io.inputReady
+  fix_to_float_b.io.s_axis_a_tvalid := io.inputReady
+
+  fix_to_float_a.io.s_axis_a_tdata := io.divident
+  fix_to_float_b.io.s_axis_a_tdata := io.divisor
+
+  float_div.io.s_axis_a_tdata := fix_to_float_a.io.m_axis_result_tdata
+  float_div.io.s_axis_a_tvalid := fix_to_float_a.io.m_axis_result_tvalid
+  float_div.io.s_axis_b_tdata := fix_to_float_b.io.m_axis_result_tdata
+  float_div.io.s_axis_b_tvalid := fix_to_float_b.io.m_axis_result_tvalid
+
+  float_to_fix.io.s_axis_a_tdata := float_div.io.m_axis_result_tdata
+  float_to_fix.io.s_axis_a_tvalid := float_div.io.m_axis_result_tvalid
+
+  io.result := float_to_fix.io.m_axis_result_tdata
+  io.resultReady := float_to_fix.io.m_axis_result_tvalid
+
+}

--- a/fpga/src/main/scala/tools/Interfaces.scala
+++ b/fpga/src/main/scala/tools/Interfaces.scala
@@ -5,12 +5,13 @@ import Chisel.log2Up
 import chisel3.experimental.FixedPoint
 
 object STD {
-  val pointNum = 4
-  val linenum = 4
+  val pointNum = 8
+  val linenum = 12
+  val pointDimension = 4
   val pointIndexWidth = 16.W
   val fixedWidth = 16.W
-  val binaryPoint = 12.BP
   val binaryPointVal = 12
+  val binaryPoint = binaryPointVal.BP
   val colorEnabled = true
   val colorWidth = 4.W
 
@@ -39,8 +40,8 @@ class DataFrame extends Bundle {
   val points = Vec(STD.pointNum, new Point)
   val lines = Vec(STD.linenum, new Line)
   val matrix = Vec(
-    STD.pointNum,
-    Vec(STD.pointNum, STD.FP)
+    STD.pointDimension,
+    Vec(STD.pointDimension, STD.FP)
   )
 }
 

--- a/fpga/src/main/scala/tools/helpers.scala
+++ b/fpga/src/main/scala/tools/helpers.scala
@@ -26,7 +26,10 @@ object helpers {
 
   def fp = (v: Double) => v.F(STD.fixedWidth, STD.binaryPoint)
 
-  val divFP = (a: FixedPoint, w: FixedPoint) =>
-    ((a << STD.binaryPointVal).asSInt() / w.asSInt())
+  def divFP = (a: FixedPoint, w: FixedPoint) => {
+    val divisor = RegNext(a << STD.binaryPointVal).asSInt()
+    val divident = RegNext(w).asSInt()
+    (divisor / divident)
       .asFixedPoint(STD.binaryPoint)
+  }
 }


### PR DESCRIPTION
Adds the matrix to the dataframe and extends number of points and lines for
a 3d cube. Also adds a `FixPointDivision` module that uses Vivado IP
_Floating Point Operator_ modules to perform FixedPoint division used in
the normalization.

The statemachine is a _bit_ messy in order to get all the timing right, as we now have 3 intermediate registers that need to be loaded in different parts of the rendering pipeline.

- The Rotation has been moved til after the frame loading, and will now operate only on two points at a time (since we are limited by bresenham this should be fine). 
- The output pixels from the rotation is loaded into a `pixel` buffer, that keeps the calculated pixels, so that we don't need to recalculate when clearing, thus we are able to not wait at all before starting the clearing operation.
- The normalization uses a new `FixPointDivision` module to perform the division for `x` and `y` after the matrix product. We do this using the [Vivado Floating-Point Operator](https://www.xilinx.com/support/documentation/ip_documentation/floating_point/v7_1/pg060-floating-point.pdf). The module consists of four instances of the module performing different operations. Two instances that convert from FixedPoint to Floating-point (as the operator can only operate on floating-point). One to perform the division itself, and a last one to convert back from floating-point to fixedpoint. The entire process takes 39 cycles with `16 bit` fixedpoints and `32 bit` floating points for the calculation itself.

### Configuring the floating point operators
To create the correct configuration for the floating point operator modules. Create three modules from the IP catalog in vivado:
1. One module with the name `fix_to_float`. Configured for fixpoint to floating point conversion. Select `non-blocking` in  the interface tab, and use floating point with `4` interger bits and `12` binarypoint bits. The output should be single precision floats (32 bits).
2. One module with the name `float_div`. Configured for division. Select `non-blocking` again and use single precision bits for both inputs and output.
3. One module with the name `float_to_fix`. Configured for floating to fixpoint conversion. Select `non-blocking` and use 32 bit single precision bits for input and fixpoints with `4` bits integer and `12` bits binarpoint bits.