### PR TITLE
Double buffer v2

### DIFF
--- a/fpga/src/main/scala/Main.scala
+++ b/fpga/src/main/scala/Main.scala
@@ -133,29 +133,30 @@ class Main extends Module {
     vgaBlanking.io.clk_out := clock
     vgaBlanking.io.input := vga.io.blanking
 
-    fb.io.frameDone := vga.io.frameDone
+    val frame_done = Module(new CDC)
+    frame_done.io.clk_in := vgaClock.io.clk_pix
+    frame_done.io.clk_out := clock
+    frame_done.io.input := vga.io.frameDone
+    fb.io.frameDone := frame_done.io.output
 
     vgaClock.io.clk := clock
 
-    withClock(vgaClock.io.clk_pix) {
-      vga.io.clock := vgaClock.io.clk_pix
-      vga.io.reset := ~io.aresetn
-      fb.io.readEnable := vga.io.dataEnable
+    vga.io.clock := vgaClock.io.clk_pix
+    vga.io.reset := ~io.aresetn
+    fb.io.readEnable := vga.io.dataEnable
 
-      vga.io.data := fb.io.readVal
-      fb.io.readClock := vgaClock.io.clk_pix
-      fb.io.readX := vga.io.selX
-      fb.io.readY := vga.io.selY
+    vga.io.data := fb.io.readVal
+    fb.io.readClock := vgaClock.io.clk_pix
+    fb.io.readX := vga.io.selX
+    fb.io.readY := vga.io.selY
 
-      // Delay all VGA signals by 1 cycle due to 1 cycle delay from memory reads
-      io.vga_hsync := delay(vga.io.hsync)
-      io.vga_vsync := delay(vga.io.vsync)
+    // Delay all VGA signals by 1 cycle due to 1 cycle delay from memory reads
+    io.vga_hsync := delay(vga.io.hsync)
+    io.vga_vsync := delay(vga.io.vsync)
 
-      io.vga_r := delay(vga.io.out.r)
-      io.vga_g := delay(vga.io.out.g)
-      io.vga_b := delay(vga.io.out.b)
-
-    }
+    io.vga_r := delay(vga.io.out.r)
+    io.vga_g := delay(vga.io.out.g)
+    io.vga_b := delay(vga.io.out.b)
 
     val (cnt, cntWrap) = Counter(true.B, 100000000)
 

--- a/fpga/src/main/scala/Main.scala
+++ b/fpga/src/main/scala/Main.scala
@@ -106,6 +106,10 @@ class Main extends Module {
     fb.io.writeEnable := bresenhams.io.writeEnable
     fb.io.writePixel := bresenhams.io.writePixel
     fb.io.writeVal := bresenhams.io.writeVal
+    fb.io.clear := stateMachine.io.fbClear
+
+    stateMachine.io.fbReady := fb.io.ready
+    stateMachine.io.fbClearStarted := fb.io.clearStarted
 
     bresenhams.io.start := stateMachine.io.bhStartRegular
     bresenhams.io.startClear := stateMachine.io.bhStartClear
@@ -128,6 +132,8 @@ class Main extends Module {
     vgaBlanking.io.clk_in := vgaClock.io.clk_pix
     vgaBlanking.io.clk_out := clock
     vgaBlanking.io.input := vga.io.blanking
+
+    fb.io.frameDone := vga.io.frameDone
 
     vgaClock.io.clk := clock
 

--- a/fpga/src/main/scala/fb/FrameBuffer.scala
+++ b/fpga/src/main/scala/fb/FrameBuffer.scala
@@ -8,6 +8,7 @@ import tools._
 class FrameBuffer(width: Int, height: Int) extends Module {
 
   val colorDepth: Int = 4 // Bit width of a single color channel
+  val pixel_count = width * height
 
   val io = IO(new Bundle {
     val writePixel = Input(new Pixel)
@@ -17,30 +18,102 @@ class FrameBuffer(width: Int, height: Int) extends Module {
     val readY = Input(UInt((log2Up(height) + 1).W))
     val readVal = Output(Bool())
     val readEnable = Input(Bool())
+    val clear = Input(Bool())
+    val ready = Output(Bool())
+    val clearStarted = Output(Bool())
 
     val readClock = Input(Clock())
+    val frameDone = Input(Bool())
   })
 
+  io.clearStarted := false.B
+
+  val frame_done = Module(new CDC)
+  frame_done.io.clk_in := io.readClock
+  frame_done.io.clk_out := clock
+  frame_done.io.input := io.frameDone
+  val frameDone = frame_done.io.output ^ RegNext(frame_done.io.output)
+
+  val fb_internal =
+    Module(
+      new Bram_sdp(
+        1,
+        2 * math.pow(2, log2Up(pixel_count)).toInt /*, "./bugge_large.mem"*/
+      )
+    )
+
+  val init :: clear :: idle :: active :: Nil = Enum(4)
+  val state = RegInit(idle)
+  val fb_clear_addr = RegInit(0.U(log2Up(pixel_count).W))
+  val fb_write_addr = RegInit(0.U(log2Up(pixel_count).W))
+  val current_buffer = RegInit(0.U)
+  val write_val = Wire(Bool())
+
+  io.ready := state === active
+
+  when(frameDone) {
+    current_buffer := ~current_buffer
+  }
+
+  switch(state) {
+    is(init) {
+      when(io.clear) {
+        io.clearStarted := true.B
+        state := clear
+        fb_clear_addr := 0.U
+      }.otherwise {
+        state := active
+      }
+    }
+
+    is(clear) {
+      when(fb_clear_addr === (pixel_count - 1).U) {
+        state := active
+      }
+      fb_clear_addr := fb_clear_addr + 1.U
+    }
+
+    is(idle) {
+      when(frameDone) {
+        state := init
+      }
+    }
+
+    is(active) {
+      when(frameDone) {
+        state := init
+      }
+    }
+  }
+
+  when(state === clear) {
+    fb_write_addr := fb_clear_addr
+    write_val := false.B
+  }.otherwise {
+    fb_write_addr := io.writePixel.y * width.U + io.writePixel.x
+    write_val := io.writeVal
+  }
+
+  val out_of_frame = io.writePixel.x > width.U || io.writePixel.y > height.U
+
+  fb_internal.io.clk_write := clock
+  //fb.io.reset := reset
+  io.readEnable := DontCare
+  //fb.io.read_enable := io.readEnable
+
+  fb_internal.io.write_enable := RegNext(
+    io.writeEnable && !out_of_frame
+  ) || (state === clear)
+  fb_internal.io.write_addr := Cat(current_buffer, fb_write_addr)
+  fb_internal.io.data_in := write_val.asUInt()
+
+  //fb.io.writeport_enable := DontCare
+  //fb.io.read_out_reg_en := true.B
+
   withClock(io.readClock) {
-
-    val fb_internal =
-      Module(new Bram_sdp(1, width * height /*, "./bugge_large.mem"*/ ))
-    fb_internal.io.clk_write := clock
-    //fb.io.reset := reset
-    io.readEnable := DontCare
-    //fb.io.read_enable := io.readEnable
-
-    fb_internal.io.write_enable := io.writeEnable
-    fb_internal.io.write_addr := io.writePixel.y * width.U + io.writePixel.x
-    fb_internal.io.data_in := io.writeVal.asUInt()
-    io.writeVal := DontCare
-
-    //fb.io.writeport_enable := DontCare
-    //fb.io.read_out_reg_en := true.B
-
     val read_addr = RegInit(0.U(20.W))
     fb_internal.io.clk_read := io.readClock
-    fb_internal.io.read_addr := read_addr
+    fb_internal.io.read_addr := Cat(~current_buffer, read_addr)
     when(io.readY === 0.U && io.readX === 0.U) {
       read_addr := 0.U
     }
@@ -50,7 +123,7 @@ class FrameBuffer(width: Int, height: Int) extends Module {
     //r(0) := fb.io.data_out(colorDepth - 1, 0)
     //r(1) := fb.io.data_out(2 * colorDepth - 1, colorDepth)
     //r(2) := fb.io.data_out(3 * colorDepth - 1, 2 * colorDepth)
-
-    io.readVal := fb_internal.io.data_out.asBool()
   }
+
+  io.readVal := fb_internal.io.data_out.asBool()
 }

--- a/fpga/src/main/scala/fb/FrameBuffer.scala
+++ b/fpga/src/main/scala/fb/FrameBuffer.scala
@@ -9,13 +9,14 @@ class FrameBuffer(width: Int, height: Int) extends Module {
 
   val colorDepth: Int = 4 // Bit width of a single color channel
   val pixel_count = width * height
+  val buf_width = math.pow(2, log2Up(pixel_count)).toInt
 
   val io = IO(new Bundle {
     val writePixel = Input(new Pixel)
     val writeVal = Input(Bool())
     val writeEnable = Input(Bool())
-    val readX = Input(UInt((log2Up(width) + 1).W))
-    val readY = Input(UInt((log2Up(height) + 1).W))
+    val readX = Input(UInt(log2Up(width).W))
+    val readY = Input(UInt(log2Up(height).W))
     val readVal = Output(Bool())
     val readEnable = Input(Bool())
     val clear = Input(Bool())
@@ -28,30 +29,26 @@ class FrameBuffer(width: Int, height: Int) extends Module {
 
   io.clearStarted := false.B
 
-  val frame_done = Module(new CDC)
-  frame_done.io.clk_in := io.readClock
-  frame_done.io.clk_out := clock
-  frame_done.io.input := io.frameDone
-  val frameDone = frame_done.io.output ^ RegNext(frame_done.io.output)
+  val frameDone = io.frameDone
 
   val fb_internal =
     Module(
       new Bram_sdp(
         1,
-        2 * math.pow(2, log2Up(pixel_count)).toInt /*, "./bugge_large.mem"*/
+        2 * buf_width /*, "./bugge_large.mem"*/
       )
     )
 
   val init :: clear :: idle :: active :: Nil = Enum(4)
   val state = RegInit(idle)
-  val fb_clear_addr = RegInit(0.U(log2Up(pixel_count).W))
-  val fb_write_addr = RegInit(0.U(log2Up(pixel_count).W))
+  val fb_clear_addr = RegInit(0.U(log2Up(buf_width).W))
+  val fb_write_addr = RegInit(0.U(log2Up(buf_width).W))
   val current_buffer = RegInit(0.U)
   val write_val = Wire(Bool())
 
   io.ready := state === active
 
-  when(frameDone) {
+  when(frameDone && io.clear) {
     current_buffer := ~current_buffer
   }
 
@@ -69,8 +66,9 @@ class FrameBuffer(width: Int, height: Int) extends Module {
     is(clear) {
       when(fb_clear_addr === (pixel_count - 1).U) {
         state := active
+      }.otherwise {
+        fb_clear_addr := fb_clear_addr + 1.U
       }
-      fb_clear_addr := fb_clear_addr + 1.U
     }
 
     is(idle) {
@@ -94,7 +92,8 @@ class FrameBuffer(width: Int, height: Int) extends Module {
     write_val := io.writeVal
   }
 
-  val out_of_frame = io.writePixel.x > width.U || io.writePixel.y > height.U
+  val out_of_frame =
+    io.writePixel.x >= width.U || io.writePixel.x < 0.U || io.writePixel.y >= height.U || io.writePixel.y < 0.U
 
   fb_internal.io.clk_write := clock
   //fb.io.reset := reset
@@ -102,27 +101,19 @@ class FrameBuffer(width: Int, height: Int) extends Module {
   //fb.io.read_enable := io.readEnable
 
   fb_internal.io.write_enable := RegNext(
-    io.writeEnable && !out_of_frame
+    io.writeEnable && !out_of_frame && io.ready
   ) || (state === clear)
-  fb_internal.io.write_addr := Cat(current_buffer, fb_write_addr)
+  fb_internal.io.write_addr := Cat(~current_buffer, fb_write_addr)
   fb_internal.io.data_in := write_val.asUInt()
 
   //fb.io.writeport_enable := DontCare
   //fb.io.read_out_reg_en := true.B
 
   withClock(io.readClock) {
-    val read_addr = RegInit(0.U(20.W))
+    val read_addr = Wire(UInt(log2Up(buf_width).W))
+    read_addr := io.readY * width.U + io.readX
     fb_internal.io.clk_read := io.readClock
-    fb_internal.io.read_addr := Cat(~current_buffer, read_addr)
-    when(io.readY === 0.U && io.readX === 0.U) {
-      read_addr := 0.U
-    }
-      .elsewhen(io.readY < height.U && io.readX < width.U) {
-        read_addr := read_addr + 1.U
-      }
-    //r(0) := fb.io.data_out(colorDepth - 1, 0)
-    //r(1) := fb.io.data_out(2 * colorDepth - 1, colorDepth)
-    //r(2) := fb.io.data_out(3 * colorDepth - 1, 2 * colorDepth)
+    fb_internal.io.read_addr := Cat(current_buffer, read_addr)
   }
 
   io.readVal := fb_internal.io.data_out.asBool()

--- a/fpga/src/main/scala/tools/CDC.scala
+++ b/fpga/src/main/scala/tools/CDC.scala
@@ -11,7 +11,7 @@ class CDC extends Module {
     val output = Output(Bool())
   })
 
-  val input_toggle = Reg(Bool())
+  val input_toggle = RegInit(false.B)
 
   // The input_toggle register is used as a toggle register
   // based on the input from the source domain
@@ -20,7 +20,7 @@ class CDC extends Module {
   }
 
   // Shift register used to cross the value into the destination domain
-  val out_reg = Reg(Bits(4.W))
+  val out_reg = RegInit(0.U(4.W))
 
   // We shift the value from source domain into the output domain
   withClock(io.clk_out) {

--- a/fpga/src/main/scala/tools/CDC.scala
+++ b/fpga/src/main/scala/tools/CDC.scala
@@ -11,23 +11,23 @@ class CDC extends Module {
     val output = Output(Bool())
   })
 
-  val input_toggle = RegInit(false.B)
+  val input_toggle_wire = Wire(Bool())
 
   // The input_toggle register is used as a toggle register
   // based on the input from the source domain
   withClock(io.clk_in) {
+    val input_toggle = RegInit(false.B)
     input_toggle := input_toggle ^ io.input
+    input_toggle_wire := input_toggle
   }
 
-  // Shift register used to cross the value into the destination domain
-  val out_reg = RegInit(0.U(4.W))
-
-  // We shift the value from source domain into the output domain
   withClock(io.clk_out) {
-    out_reg := Cat(out_reg(2, 0), input_toggle)
+    // Shift register used to cross the value into the destination domain
+    val out_reg = RegInit(0.U(4.W))
+    // We shift the value from source domain into the output domain
+    out_reg := Cat(out_reg(2, 0), input_toggle_wire)
+    // The output is high when we detect a pulse
+    io.output := out_reg(3) ^ out_reg(2)
   }
-
-  // The output is high when we detect a pulse
-  io.output := out_reg(3) ^ out_reg(2)
 
 }

--- a/fpga/src/main/scala/vga/VGA.scala
+++ b/fpga/src/main/scala/vga/VGA.scala
@@ -30,14 +30,14 @@ class VGA extends Module {
     val (counterHsync, counterHsyncWrap) = Counter(0 to 800)
     val (counterVsync, counterVsyncWrap) = Counter(counterHsyncWrap, 525)
 
-    io.hsync := counterHsync >= (640 + 16).U & counterHsync < (640 + 16 + 96).U
-    io.vsync := counterVsync >= (480 + 10).U & counterVsync < (480 + 10 + 2).U
+    io.hsync := !(counterHsync >= (640 + 16).U & counterHsync < (640 + 16 + 96).U)
+    io.vsync := !(counterVsync >= (480 + 10).U & counterVsync < (480 + 10 + 2).U)
     io.dataEnable := counterHsync < 640.U & counterVsync < 480.U
 
     // Output high when we are in this space in the blanking interval
     // To implement verical sync & avoid tearing
     io.blanking := counterVsync > 480.U & counterVsync < 522.U
-    io.frameDone := counterVsync === 480.U && counterHsync === 640.U
+    io.frameDone := counterVsync === 480.U && counterHsync === 800.U
 
     io.selX := counterHsync
     io.selY := counterVsync

--- a/fpga/src/main/scala/vga/VGA.scala
+++ b/fpga/src/main/scala/vga/VGA.scala
@@ -20,6 +20,7 @@ class VGA extends Module {
 
     // Is the current output in the blanking interval
     val blanking = Output(Bool())
+    val frameDone = Output(Bool())
 
     val clock = Input(Clock())
     val reset = Input(Bool())
@@ -36,6 +37,7 @@ class VGA extends Module {
     // Output high when we are in this space in the blanking interval
     // To implement verical sync & avoid tearing
     io.blanking := counterVsync > 480.U & counterVsync < 522.U
+    io.frameDone := counterVsync === 480.U && counterHsync === 640.U
 
     io.selX := counterHsync
     io.selY := counterVsync


### PR DESCRIPTION
Double buffering. Started from scratch.

This works by switching the buffer every frame, and drawing to that buffer. We can choose if we want to clear the buffer before drawing or not. Currently this has feature parity with the old clearing, by just clearing the entire buffer every time we draw a new frame.

This ups the drawing time from `128 000` cycles to `1 290 000` cycles. This includes the ~300 000 cycles needed to clear the buffer before drawing.