### PR TITLE
FB bugfix

### DIFF
--- a/fpga/src/main/scala/tools/CDC.scala
+++ b/fpga/src/main/scala/tools/CDC.scala
@@ -11,12 +11,14 @@ class CDC extends Module {
     val output = Output(Bool())
   })
 
-  val input_toggle = RegInit(false.B)
+  val input_toggle_wire = Wire(Bool())
 
   // The input_toggle register is used as a toggle register
   // based on the input from the source domain
   withClock(io.clk_in) {
+    val input_toggle = RegInit(false.B)
     input_toggle := input_toggle ^ io.input
+    input_toggle_wire := input_toggle
   }
 
   // Shift register used to cross the value into the destination domain
@@ -24,7 +26,7 @@ class CDC extends Module {
 
   // We shift the value from source domain into the output domain
   withClock(io.clk_out) {
-    out_reg := Cat(out_reg(2, 0), input_toggle)
+    out_reg := Cat(out_reg(2, 0), input_toggle_wire)
   }
 
   // The output is high when we detect a pulse

--- a/fpga/src/main/scala/vga/VGA.scala
+++ b/fpga/src/main/scala/vga/VGA.scala
@@ -30,14 +30,14 @@ class VGA extends Module {
     val (counterHsync, counterHsyncWrap) = Counter(0 to 800)
     val (counterVsync, counterVsyncWrap) = Counter(counterHsyncWrap, 525)
 
-    io.hsync := counterHsync >= (640 + 16).U & counterHsync < (640 + 16 + 96).U
-    io.vsync := counterVsync >= (480 + 10).U & counterVsync < (480 + 10 + 2).U
+    io.hsync := !(counterHsync >= (640 + 16).U & counterHsync < (640 + 16 + 96).U)
+    io.vsync := !(counterVsync >= (480 + 10).U & counterVsync < (480 + 10 + 2).U)
     io.dataEnable := counterHsync < 640.U & counterVsync < 480.U
 
     // Output high when we are in this space in the blanking interval
     // To implement verical sync & avoid tearing
     io.blanking := counterVsync > 480.U & counterVsync < 522.U
-    io.frameDone := counterVsync === 480.U && counterHsync === 640.U
+    io.frameDone := counterVsync === 480.U && counterHsync === 800.U
 
     io.selX := counterHsync
     io.selY := counterVsync


### PR DESCRIPTION
I cannot figure out completely what's wrong here. 

I found an issue where the clock crossing really didn't work at all, since the register to read from one of the clock was not set up properly. Apparently you need to have the `RegInit` inside the `withClock` block :upside_down_face:.  Sadly this did not completely fix the issue though. 

Currently this branch has issues with both
- flickering in the top part of the screen (the area where the flickering occurs can be moved by changing when we switch buffers)
- Screen freezes every ~1 second (and stays frozen for the same amount of time