### PR TITLE
FPGA timing improvements

### DIFF
--- a/fpga/src/main/scala/Main.scala
+++ b/fpga/src/main/scala/Main.scala
@@ -82,12 +82,18 @@ class Main extends Module {
     rotator.io.mat4 := renderingFrame.matrix
     //rotator.io.mat4 := DontCare
     // Inputs to rotator are ready one cycle after loadNextFrame
-    rotator.io.inputReady := RegNext(stateMachine.io.loadNextPoints)
+    rotator.io.inputReady := RegNext(RegNext(stateMachine.io.loadNextPoints))
+    val currentCalcPointIndex = RegNext(
+      VecInit(
+        renderingFrame.lines(stateMachine.io.calcLineIndex).index1,
+        renderingFrame.lines(stateMachine.io.calcLineIndex).index2
+      )
+    )
     rotator.io.inPoints(0) := renderingFrame.points(
-      renderingFrame.lines(stateMachine.io.calcLineIndex).index1
+      currentCalcPointIndex(0)
     )
     rotator.io.inPoints(1) := renderingFrame.points(
-      renderingFrame.lines(stateMachine.io.calcLineIndex).index2
+      currentCalcPointIndex(1)
     )
     stateMachine.io.pixelCalculationReady := rotator.io.outputReady
 
@@ -96,10 +102,10 @@ class Main extends Module {
     // Load computed pixels into this frame's rendered points for immediate access later
     when(stateMachine.io.loadNextPixels) {
       renderedPixels(
-        renderingFrame.lines(stateMachine.io.calcLineIndex).index1
+        currentCalcPointIndex(0)
       ) := rotator.io.out(0)
       renderedPixels(
-        renderingFrame.lines(stateMachine.io.calcLineIndex).index2
+        currentCalcPointIndex(1)
       ) := rotator.io.out(1)
     }
 

--- a/fpga/src/main/scala/matrix/Rotator.scala
+++ b/fpga/src/main/scala/matrix/Rotator.scala
@@ -69,17 +69,18 @@ class Rotator(points: Int = STD.pointNum, dimension: Int = STD.pointDimension)
     io.outFP(i).w := mvp.io.outVec4(3)
 
     val normalizer = Module(new Normalizer)
-    normalizer.io.inputReady := io.inputReady
     outputs(i) := normalizer.io.outputReady
 
-    normalizer.io.point.x := mvp.io.outVec4(0)
-    normalizer.io.point.y := mvp.io.outVec4(1)
-    normalizer.io.point.z := mvp.io.outVec4(2)
-    normalizer.io.point.w := mvp.io.outVec4(3)
+    // RegNext to not break timing
+    normalizer.io.inputReady := RegNext(io.inputReady)
+    normalizer.io.point.x := RegNext(mvp.io.outVec4(0))
+    normalizer.io.point.y := RegNext(mvp.io.outVec4(1))
+    normalizer.io.point.z := RegNext(mvp.io.outVec4(2))
+    normalizer.io.point.w := RegNext(mvp.io.outVec4(3))
 
-    io.out(i).x := normalizer.io.pixel.x
-    io.out(i).y := normalizer.io.pixel.y
+    io.out(i).x := RegNext(normalizer.io.pixel.x)
+    io.out(i).y := RegNext(normalizer.io.pixel.y)
   }
 
-  io.outputReady := outputs.reduce((a, b) => a & b)
+  io.outputReady := RegNext(outputs.reduce((a, b) => a & b))
 }


### PR DESCRIPTION
Try to improve timing a bit.
This removes some of the timing issues, but we still have issues in the MVP (due to Vivado placing registers on different sides of the chip, so the data path is super long, which is stupid).

Still have not looked at the intra-clock paths. (vgaClock -> sys_clk). We need to set constraints for these inter-clock paths.