### PR TITLE
Implement support for clearing the framebuffer while reading

### DIFF
--- a/fpga/src/main/scala/vga/VGA.scala
+++ b/fpga/src/main/scala/vga/VGA.scala
@@ -47,11 +47,15 @@ class VGA extends Module {
       io.out := 0.U.asTypeOf(new Color)
     }.otherwise {
       //io.out := io.data
-      io.out := Mux(
-        io.data,
-        STD.mainColor.asTypeOf(new Color),
-        STD.bgColor.asTypeOf(new Color)
-      )
+      when(io.selX === 0.U) {
+        io.out := STD.bgColor.asTypeOf(new Color)
+      }.otherwise {
+        io.out := Mux(
+          io.data,
+          STD.mainColor.asTypeOf(new Color),
+          STD.bgColor.asTypeOf(new Color)
+        )
+      }
     }
   }
 }


### PR DESCRIPTION
This allows us to start clearing the framebuffer while reading, by just
starting the clearing immediately and clear "after" the reading until
the buffer is switched.
